### PR TITLE
Bugfix/removed forced initialisation

### DIFF
--- a/InstaFailAccuracy/Installers/InstaGameInstaller.cs
+++ b/InstaFailAccuracy/Installers/InstaGameInstaller.cs
@@ -18,7 +18,7 @@ namespace InstaFailAccuracy.Installers
 		{
 			if (_config.EnableInstaFailAcc && !_gameplayCoreSceneSetupData.gameplayModifiers.noFailOn0Energy)
 			{
-				Container.BindInterfacesTo<InstaFailAccuracyGameController>().AsSingle().NonLazy();
+				Container.BindInterfacesTo<InstaFailAccuracyGameController>().AsSingle();
 			}
 		}
 	}

--- a/InstaFailAccuracy/manifest.json
+++ b/InstaFailAccuracy/manifest.json
@@ -3,7 +3,7 @@
   "id": "InstaFailAccuracy",
   "name": "InstaFailAccuracy",
   "author": "Shoko84",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Makes you fail if you're under a specific accuracy!",
   "gameVersion": "1.13.2",
   "dependsOn": {


### PR DESCRIPTION
This PR basically removes the forced initialization from the installer.
Zenject will implicitly create the instance as the interfaces of the controller have been bound.